### PR TITLE
Linino io

### DIFF
--- a/lib/i2c.js
+++ b/lib/i2c.js
@@ -58,7 +58,7 @@ function I2c (element, options){
                         if(callbacks.length > 0){ 
                             that.readBuffer[param].fill(0);
                             fs.read(fd, that.readBuffer[param], 0, that.bufferSize, 0,function(){
-                                new_value = parseInt(decoder.write(that.readBuffer[param]));
+                                new_value = parseFloat(decoder.write(that.readBuffer[param]));
                                 if( new_value <= (old_value - resolution) || 
                                     new_value >= (old_value + resolution) ){
                                     old_value = new_value;
@@ -91,7 +91,7 @@ function I2c (element, options){
                     that.valueFd[param]=fd;
                     that.readBuffer[param].fill(0);
                     fs.read(that.valueFd[param], that.readBuffer[param], 0, that.bufferSize , 0,function(value){
-                        callback(null, parseInt(decoder.write(that.readBuffer[param])));
+                        callback(null, parseFloat(decoder.write(that.readBuffer[param])));
                     });  
                 });
             });
@@ -99,7 +99,7 @@ function I2c (element, options){
         else{
             that.readBuffer[param].fill(0);
             fs.read(that.valueFd[param], that.readBuffer[param], 0, that.bufferSize, 0,function(value){
-                callback(null, parseInt(decoder.write(that.readBuffer[param])));                
+                callback(null, parseFloat(decoder.write(that.readBuffer[param])));                
             }); 
         }        
     };
@@ -131,7 +131,7 @@ function I2c (element, options){
     
     function readSync(valueFd, readBuffer, bufferSize) {
         fs.readSync(valueFd, readBuffer, 0, bufferSize, 0);
-        return parseInt(decoder.write(readBuffer));	
+        return parseFloat(decoder.write(readBuffer));	
     };
 
     function paramReadPath(paramPath, callback){
@@ -139,9 +139,8 @@ function I2c (element, options){
             fs.open(paramPath, 'r',function(err,fd){
                 callback(fd);
             });
-    });
-}
-    
+		});
+	}; 
 }
 
 exports.I2c = I2c;


### PR DESCRIPTION
fixed i2c read errors. now use parseFloat
